### PR TITLE
fix: get bucket location default coerce behaviour

### DIFF
--- a/source/api/controlplane/system/runtime/app.py
+++ b/source/api/controlplane/system/runtime/app.py
@@ -354,7 +354,7 @@ def list_s3_buckets():
             bucket["Name"]
             # Only get the buckets from your region
             # null location constraint means its us-east-1
-            for bucket in buckets if s3_client.get_bucket_location(Bucket=bucket["Name"]).get("LocationConstraint","us-east-1") == REGION
+            for bucket in buckets if (s3_client.get_bucket_location(Bucket=bucket["Name"]).get("LocationConstraint") or "us-east-1") == REGION
         ]
 
     except Exception as e:


### PR DESCRIPTION
## Overview
It was noticed that when deploying and selecting buckets present in `us-east-1` the **Source S3 Bucket** would always return an empty list
<img width="1011" alt="Screenshot 2023-05-08 at 09 26 51" src="https://user-images.githubusercontent.com/1455141/236775119-b1d39d3f-fab7-41f9-8495-56f72c63a832.png">

It was observed the behaviour is due to `Dict#get(key, [default])` behaviour when a `None` is present in the dictionary as is returned by the S3 SDK
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/1455141/236775388-525b8e6e-54b8-486c-8c24-627b946c8f46.png">

## Actual Behaviour
Using the below example we can replicate the bug
```python
print("None:",
    ({
        "LocationConstraint": None
    }.get("LocationConstraint", "us-east-1"))
)
print("Empty",
    ({}.get("LocationConstraint", "us-east-1"))
)
print("Present:",
    ({
        "LocationConstraint": "us-west-2"
    }.get("LocationConstraint", "us-east-1"))
)
```
We can observe the printed values as:
```
None: None
Empty us-east-1
Present: us-west-2
```
This is incorrect as the expected value printed for `None: ` should be `us-east-1`

## Expected Behaviour
Adjusting the code slightly to `or` on the `us-east-1` should return the expected values: 
```python
print("None:",
    ({
        "LocationConstraint": None
    }.get("LocationConstraint") or "us-east-1")
)
print("Empty",
    ({}.get("LocationConstraint") or "us-east-1")
)
print("Present:",
    ({
        "LocationConstraint": "us-west-2"
    }.get("LocationConstraint") or "us-east-1")
)
```
Will return the following:
```
None: us-east-1
Empty us-east-1
Present: us-west-2
```

I hope this helps :)

## Disclaimer
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.