### PR TITLE
fix(samples/plugins): update directory to capitalised version of plugin

### DIFF
--- a/samples/source/mre-plugin-samples/cdk/stacks/mre_plugins_stack.py
+++ b/samples/source/mre-plugin-samples/cdk/stacks/mre_plugins_stack.py
@@ -240,7 +240,7 @@ class MrePluginsStack(Stack):
 
                 # Create the Lambda function for the plugin
 
-                if os.path.isfile(f"../plugins/{plugin_name}/Dockerfile"):
+                if os.path.isfile(f"../Plugins/{plugin_name}/Dockerfile"):
                     self.plugin_function = self._create_docker_lambda(
                         plugin_config,
                         plugin_config_name,
@@ -454,7 +454,7 @@ class MrePluginsStack(Stack):
             description=plugin_config["MRE"]["Plugin"].get("Description"),
             function_name=function_name,
             code=_lambda.DockerImageCode.from_image_asset(
-                f"../plugins/{plugin_name}",
+                f"../Plugins/{plugin_name}",
                 build_args={
                     "PLUGIN_NAME": function_name,
                 },
@@ -480,7 +480,7 @@ class MrePluginsStack(Stack):
             description=plugin_config["MRE"]["Plugin"].get("Description"),
             function_name=plugin_name,
             runtime=_lambda.Runtime.PYTHON_3_8,
-            code=_lambda.Code.from_asset(f"../plugins/{plugin_name}/package"),
+            code=_lambda.Code.from_asset(f"../Plugins/{plugin_name}/package"),
             handler=plugin_config["Lambda"].get(
                 "Handler", f"{plugin_name}.lambda_handler"
             ),


### PR DESCRIPTION
## Description of changes:
Fixes up a typo when attempting to reference a lowercase `plugins` folder which results in assets not being able to be located within the CDK deployment

<img width="1280" alt="image" src="https://github.com/awslabs/aws-media-replay-engine/assets/1455141/214c909b-43fd-4744-9023-0393b6041f4b">

This prevents the `./build-and-deploy.sh --app plugin-samples` from executing successfully

The references should be capitalised <kbd>p</kbd> to match the file path
<img height="500" alt="image" src="https://github.com/awslabs/aws-media-replay-engine/assets/1455141/eb58bb24-35f3-4080-bcf7-1833af76d509">

## Disclaimer
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.