### PR TITLE
fix(deploy/lambda_layer): use amazonlinux 2 for building

### DIFF
--- a/deployment/lambda_layer_factory/Dockerfile
+++ b/deployment/lambda_layer_factory/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 WORKDIR /
 RUN yum update -y


### PR DESCRIPTION
## Issue #, if available:
- [issues/13](https://github.com/awslabs/aws-media-replay-engine/issues/13)

## Description of changes:
Explicitly state `amazonlinux:2` version

## Disclaimer
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.